### PR TITLE
Arbitrary T and P response support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,14 @@ LIB_SRCFILES = \
   src_lib/gpu_utils.cu \
   src_lib/local_map_to_global.cu \
   src_lib/map2tod.cu \
+  src_lib/map2tod_response.cu \
   src_lib/map2tod_reference.cu \
   src_lib/map2tod_unplanned.cu \
   src_lib/misc.cu \
   src_lib/pycufft.cu \
   src_lib/test_plan_iterator.cu \
   src_lib/tod2map.cu \
+  src_lib/tod2map_response.cu \
   src_lib/tod2map_reference.cu \
   src_lib/tod2map_unplanned.cu
 

--- a/include/gpu_mm.hpp
+++ b/include/gpu_mm.hpp
@@ -18,21 +18,21 @@ struct LocalPixelization
 {
     // This constructor is intended to be called from C++.
     // The 'cell_offsets' array can be either on the CPU or GPU.
-    
+
     LocalPixelization(long nypix_global, long nxpix_global,
-		      const ksgpu::Array<long> &cell_offsets,
-		      long ystride, long polstride,
-		      bool periodic_xcoord = true);
+                      const ksgpu::Array<long> &cell_offsets,
+                      long ystride, long polstride,
+                      bool periodic_xcoord = true);
 
     // This constructor is intended to be called from python.
     // The caller is responsible for ensuring that the 'cell_offsets_cpu'
     // and 'cell_offsets_gpu' arrays have the same contents!
-    
+
     LocalPixelization(long nypix_global, long nxpix_global,
-		      const ksgpu::Array<long> &cell_offsets_cpu,
-		      const ksgpu::Array<long> &cell_offsets_gpu,
-		      long ystride, long polstride,
-		      bool periodic_xcoord = true);
+                      const ksgpu::Array<long> &cell_offsets_cpu,
+                      const ksgpu::Array<long> &cell_offsets_gpu,
+                      long ystride, long polstride,
+                      bool periodic_xcoord = true);
 
     // Global pixelization
     const long nypix_global;
@@ -44,7 +44,7 @@ struct LocalPixelization
     ksgpu::Array<long> cell_offsets_gpu;   // not 'const', since DynamicMap can modify
     const long ystride;
     const long polstride;
-    
+
     long nycells;   // same as cell_offsets.shape[0]
     long nxcells;   // same as cell_offsets.shape[1]
     long npix;      // counts only local pixels, does not include factor 3 from TQU.
@@ -63,19 +63,19 @@ struct PointingPrePlan
     static constexpr int preplan_size = 1024;
 
     // This constructor allocates GPU memory, and is intended to be called from C++.
-    
+
     template<typename T>
     PointingPrePlan(const ksgpu::Array<T> &xpointing_gpu, long nypix_global, long nxpix_global,
-		    bool periodic_xcoord = true, bool debug = false);
-    
+                    bool periodic_xcoord = true, bool debug = false);
+
     // This constructor uses externally allocated GPU memory, and is intended to be called from python.
     // The 'nmt_gpu' and 'err_gpu' arrays should have length preplan_size.
-    
+
     template<typename T>
     PointingPrePlan(const ksgpu::Array<T> &xpointing_gpu, long nypix_global, long nxpix_global,
-		    const ksgpu::Array<uint> &nmt_gpu, const ksgpu::Array<uint> &err_gpu,
-		    bool periodic_xcoord = true, bool debug = false);
-    
+                    const ksgpu::Array<uint> &nmt_gpu, const ksgpu::Array<uint> &err_gpu,
+                    bool periodic_xcoord = true, bool debug = false);
+
     long nsamp = 0;
     long nypix_global = 0;
     long nxpix_global = 0;
@@ -103,7 +103,7 @@ struct PointingPrePlan
     // Copies nmt_cumsum array to host, and returns it as a numpy array.
     // Temporary hack, used in tests.test_pointing_preplan().
     ksgpu::Array<uint> get_nmt_cumsum() const;
-    
+
     std::string str() const;
 };
 
@@ -116,7 +116,7 @@ struct PointingPlan
     const bool periodic_xcoord;
 
     const PointingPrePlan pp;
-    
+
     ksgpu::Array<unsigned char> buf;
 
     // The 'buf' array logically consists of two buffers:
@@ -124,27 +124,27 @@ struct PointingPlan
     //   uint err[B];           // where B = max(pp.planner_nblocks, pp.pointing_nblocks)
     //
     // The 'plan_mt' and 'err_gpu' pointers point directly to these buffers, for convenience.
-   
+
     ulong *plan_mt = nullptr;
     uint *err_gpu = nullptr;    // 128-byte aligned
 
     // This constructor uses externally allocated GPU memory.
     template<typename T>
     PointingPlan(const PointingPrePlan &pp,
-		 const ksgpu::Array<T> &xpointing_gpu,
-		 const ksgpu::Array<unsigned char> &buf,
-		 const ksgpu::Array<unsigned char> &tmp_buf,
-		 bool debug = false);
+                 const ksgpu::Array<T> &xpointing_gpu,
+                 const ksgpu::Array<unsigned char> &buf,
+                 const ksgpu::Array<unsigned char> &tmp_buf,
+                 bool debug = false);
 
     // This constructor allocates GPU memory.
     template<typename T>
     PointingPlan(const PointingPrePlan &pp,
-		 const ksgpu::Array<T> &xpointing_gpu,
-		 bool debug = false);
-    
+                 const ksgpu::Array<T> &xpointing_gpu,
+                 bool debug = false);
+
     // Used in unit tests.
     ksgpu::Array<ulong> get_plan_mt(bool gpu) const;
-    
+
     // I needed this once for tracking down a bug.
     void _check_errflags(const std::string &where) const;
 
@@ -175,6 +175,29 @@ extern void launch_planned_tod2map(
     bool debug
 );
 
+template<typename T>
+extern void launch_response_map2tod(
+    ksgpu::Array<T> &tod,                       // shape (nsamp,) or (ndet,nt)
+    const ksgpu::Array<T> &local_map,           // total size (3 * local_pixelization.npix)
+    const ksgpu::Array<T> &xpointing,           // shape (3,nsamp) or (3,ndet,nt)    where axis 0 = {y,x,alpha}
+    const ksgpu::Array<T> &response,            // shape (ndet,2)
+    const LocalPixelization &local_pixelization, 
+    const PointingPlan &plan,
+    bool partial_pixelization,
+    bool debug
+);
+
+template<typename T>
+extern void launch_response_tod2map(
+    ksgpu::Array<T> &local_map,                 // total size (3 * local_pixelization.npix)
+    const ksgpu::Array<T> &tod,                 // shape (nsamp,) or (ndet,nt)
+    const ksgpu::Array<T> &xpointing,           // shape (3,nsamp) or (3,ndet,nt)    where axis 0 = {y,x,alpha}
+    const ksgpu::Array<T> &response,            // shape (ndet,2)
+    const LocalPixelization &local_pixelization, 
+    const PointingPlan &plan,
+    bool partial_pixelization,
+    bool debug
+);
 
 template<typename T>
 extern void launch_unplanned_map2tod(
@@ -276,20 +299,20 @@ struct ToyPointing
     // Version of constructor which allocates xpointing arrays.
     // If ndet <= 0, then the xpointing arrays will have shape (3,nt).
     // If ndet > 0, then the xpointing arrays will have shape (3,ndet,nt).
-    
+
     ToyPointing(long ndet, long nt,
-		long nypix_global,
-		long nxpix_global,
-		double scan_speed,     // map pixels per TOD sample
-		double total_drift,    // total drift over full TOD, in x-pixels
-		bool noisy = true);
+                long nypix_global,
+                long nxpix_global,
+                double scan_speed,     // map pixels per TOD sample
+                double total_drift,    // total drift over full TOD, in x-pixels
+                bool noisy = true);
 
     // Version of constructor with externally allocated xpointing arrays (intended for python)
     ToyPointing(long nypix_global, long nxpix_global,
-		double scan_speed, double total_drift,
-		const ksgpu::Array<T> &xpointing_cpu,
-		const ksgpu::Array<T> &xpointing_gpu,
-		bool noisy = true);
+                double scan_speed, double total_drift,
+                const ksgpu::Array<T> &xpointing_cpu,
+                const ksgpu::Array<T> &xpointing_gpu,
+                bool noisy = true);
 
     long nypix_global;
     long nxpix_global;
@@ -299,7 +322,7 @@ struct ToyPointing
 
     // Since ToyPointing is only used in unit tests, assume the caller
     // wants array copies on both CPU and GPU.
-    
+
     ksgpu::Array<T> xpointing_cpu;
     ksgpu::Array<T> xpointing_gpu;
 
@@ -322,6 +345,7 @@ extern void check_gpu_errflags(const uint *errflags_gpu, int nelts, const char *
 // Check arrays, in cases where we know the dimensions in advance.
 template<typename T> extern void check_tod(const ksgpu::Array<T> &tod, long nsamp, const char *where, bool on_gpu);
 template<typename T> extern void check_xpointing(const ksgpu::Array<T> &xpointing, long nsamp, const char *where, bool on_gpu);
+template<typename T> extern void check_response(const ksgpu::Array<T> &response, long nsamp_expected, long &ndet, long &nperdet, const char * where, bool on_gpu);
 template<typename T> extern void check_global_map(const ksgpu::Array<T> &map, long nypix_global, long nxpix_global, const char *where, bool on_gpu);
 template<typename T> extern void check_local_map(const ksgpu::Array<T> &map, const LocalPixelization &lpix, const char *where, bool on_gpu);
 extern void check_cell_offsets(const ksgpu::Array<long> &cell_offsets, long nycells_expected, long nxcells_expected, const char *where, bool on_gpu);
@@ -350,15 +374,15 @@ struct PointingPlanTester
     // Version of constructor with externally allocated tmp array (intended for python)
     template<typename T>
     PointingPlanTester(const PointingPrePlan &pp,
-		       const ksgpu::Array<T> &xpointing_gpu,
-		       const ksgpu::Array<unsigned char> &tmp);    
+                       const ksgpu::Array<T> &xpointing_gpu,
+                       const ksgpu::Array<unsigned char> &tmp);
 
     // Same meaning as in PointingPrePlan.
     long nsamp = 0;
     long nypix_global = 0;
     long nxpix_global = 0;
     bool periodic_xcoord;
-    
+
     long plan_nmt = 0;
     long ncl_per_threadblock = 0;
     long planner_nblocks = 0;
@@ -366,7 +390,7 @@ struct PointingPlanTester
     // All arrays are on the CPU.
     // (iypix, ixpix) = which map pixel does each time sample fall into?
     // (Computed on GPU and copied to CPU, in order to guarantee roundoff consistency with other GPU code.)
-    
+
     ksgpu::Array<int> iypix_arr;   // length nsamp
     ksgpu::Array<int> ixpix_arr;   // length nsamp
 

--- a/src_lib/tod2map.cu
+++ b/src_lib/tod2map.cu
@@ -21,9 +21,9 @@ __device__ void add_tqu(T *sp, int iy, int ix, T t, T q, T u, T w)
 
     // Warp divergence here
     if (in_cell) {
-	atomicAdd(sp + s, w*t);
-	atomicAdd(sp + s + 64*64, w*q);
-	atomicAdd(sp + s + 2*64*64, w*u);
+        atomicAdd(sp + s, w*t);
+        atomicAdd(sp + s + 64*64, w*q);
+        atomicAdd(sp + s + 2*64*64, w*u);
     }
 
     __syncwarp();
@@ -57,95 +57,95 @@ tod2map_kernel(
     T *shmem = dtype<T>::get_shmem();
 
     if constexpr (Debug) {
-	assert(blockDim.x == 32);
-	assert(blockDim.y == W);
+        assert(blockDim.x == 32);
+        assert(blockDim.y == W);
     }
-    
+
     // Threadblock has shape (32,W), so threadIdx.x is the laneId, and threadIdx.y is the warpId.
     const uint laneId = threadIdx.x;
     const uint warpId = threadIdx.y;
     uint err = 0;
-    
+
     plan_iterator<W,Debug> iterator(plan_mt, nmt, nmt_per_block);
     pixel_locator<T> px(nypix_global, nxpix_global, periodic_xcoord);
 
     // Outer loop over map cells
 
     while (iterator.get_cell()) {
-	uint icell = iterator.icell;
-	uint iycell = icell >> 10;
-	uint ixcell = icell & ((1<<10) - 1);
+        uint icell = iterator.icell;
+        uint iycell = icell >> 10;
+        uint ixcell = icell & ((1<<10) - 1);
 
-	bool valid = (iycell < nycells) && (ixcell < nxcells);	
-	long offset = valid ? cell_offsets[iycell*nxcells + ixcell] : -1;
-	err = ((offset >= 0) || partial_pixelization) ? err : errflag_not_in_pixelization;
+        bool valid = (iycell < nycells) && (ixcell < nxcells);        
+        long offset = valid ? cell_offsets[iycell*nxcells + ixcell] : -1;
+        err = ((offset >= 0) || partial_pixelization) ? err : errflag_not_in_pixelization;
 
-	if (offset >= 0) {
-	    // Zero shared memmory
-	    for (int s = 32*warpId + laneId; s < 3*64*64; s += 32*W)
-		shmem[s] = 0;
-	}
-	
-	__syncthreads();
+        if (offset >= 0) {
+            // Zero shared memmory
+            for (int s = 32*warpId + laneId; s < 3*64*64; s += 32*W)
+                shmem[s] = 0;
+        }
 
-	// Inner loop over TOD cache lines
+        __syncthreads();
 
-	while (iterator.get_cl()) {
-	    if (offset < 0)
-		continue;
-	    
-	    uint icl = iterator.icl;
-	    long s = (long(icl) << 5) + laneId;
+        // Inner loop over TOD cache lines
 
-	    T ypix = xpointing[s];
-	    T xpix = xpointing[s + nsamp];
-	    T alpha = xpointing[s + 2*nsamp];
-	    T t = tod[s];
-	    
-	    T q, u;
-	    dtype<T>::xsincos(2*alpha, &u, &q);
-	    q *= t;
-	    u *= t;
+        while (iterator.get_cl()) {
+            if (offset < 0)
+                continue;
 
-	    // Locate pixel in shared memory.
-	    px.locate(ypix, xpix, iycell, ixcell, err);
-	    
-	    add_tqu(shmem, px.iy0, px.ix0, t, q, u, (1-px.dy) * (1-px.dx));
-	    add_tqu(shmem, px.iy0, px.ix1, t, q, u, (1-px.dy) * (px.dx));
-	    add_tqu(shmem, px.iy1, px.ix0, t, q, u, (px.dy) * (1-px.dx));
-	    add_tqu(shmem, px.iy1, px.ix1, t, q, u, (px.dy) * (px.dx));
-	}
+            uint icl = iterator.icl;
+            long s = (long(icl) << 5) + laneId;
 
-	if (offset < 0)
-	    continue;
-	
-	__syncthreads();
-	
-	// Shared -> global
-	
-	for (int y = warpId; y < 64; y += W) {
-	    for (int x = laneId; x < 64; x += 32) {
-		int ss = 64*y + x;                 // shared memory offset
-		long sg = offset + y*ystride + x;  // global memory offset
+            T ypix = xpointing[s];
+            T xpix = xpointing[s + nsamp];
+            T alpha = xpointing[s + 2*nsamp];
+            T t = tod[s];
 
-		T t = shmem[ss];
-		if (!__reduce_or_sync(ALL_LANES, t != 0))
-		    continue;
+            T q, u;
+            dtype<T>::xsincos(2*alpha, &u, &q);
+            q *= t;
+            u *= t;
 
-		// Check for out-of-range memory access
-		if constexpr (Debug) {
-		    assert(polstride > 0);
-		    assert(sg >= 0);
-		    assert(sg + 2*polstride < lmap_size);
-		}
+            // Locate pixel in shared memory.
+            px.locate(ypix, xpix, iycell, ixcell, err);
 
-		atomicAdd(lmap + sg, t);
-		atomicAdd(lmap + sg + polstride, shmem[ss+64*64]);
-		atomicAdd(lmap + sg + 2*polstride, shmem[ss+2*64*64]);
-	    }
-	}
+            add_tqu(shmem, px.iy0, px.ix0, t, q, u, (1-px.dy) * (1-px.dx));
+            add_tqu(shmem, px.iy0, px.ix1, t, q, u, (1-px.dy) * (px.dx));
+            add_tqu(shmem, px.iy1, px.ix0, t, q, u, (px.dy) * (1-px.dx));
+            add_tqu(shmem, px.iy1, px.ix1, t, q, u, (px.dy) * (px.dx));
+        }
 
-	__syncthreads();
+        if (offset < 0)
+            continue;
+
+        __syncthreads();
+
+        // Shared -> global
+
+        for (int y = warpId; y < 64; y += W) {
+            for (int x = laneId; x < 64; x += 32) {
+                int ss = 64*y + x;                 // shared memory offset
+                long sg = offset + y*ystride + x;  // global memory offset
+
+                T t = shmem[ss];
+                if (!__reduce_or_sync(ALL_LANES, t != 0))
+                    continue;
+
+                // Check for out-of-range memory access
+                if constexpr (Debug) {
+                    assert(polstride > 0);
+                    assert(sg >= 0);
+                    assert(sg + 2*polstride < lmap_size);
+                }
+
+                atomicAdd(lmap + sg, t);
+                atomicAdd(lmap + sg + polstride, shmem[ss+64*64]);
+                atomicAdd(lmap + sg + 2*polstride, shmem[ss+2*64*64]);
+            }
+        }
+
+        __syncthreads();
     }
 
     // No need for __syncthreads() before write_errflags(), since main loop has __syncthreads() at bottom.
@@ -175,52 +175,52 @@ extern void launch_planned_tod2map(
     xassert_eq(local_pixelization.nypix_global, plan.nypix_global);
     xassert_eq(local_pixelization.nxpix_global, plan.nxpix_global);
     xassert_eq(local_pixelization.periodic_xcoord, plan.periodic_xcoord);
-    
+
     if (debug) {
-	tod2map_kernel<T,W,true> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
-	    (local_map.data,                            // T *lmap
-	     tod.data,                                  // const T *tod
-	     xpointing.data,                            // const T *xpointing
-	     local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
-	     plan.plan_mt,                              // const ulong *plan_mt
-	     plan.err_gpu,                              // uint *errflags
-	     plan.nsamp,                                // long nsamp
-	     plan.nypix_global,                         // int nypix_global
-	     plan.nxpix_global,                         // int nxpix_global
-	     local_pixelization.nycells,                // int nycells
-	     local_pixelization.nxcells,                // int nxcells
-	     local_pixelization.ystride,                // long ystride
-	     local_pixelization.polstride,              // long polstride
-	     plan.pp.plan_nmt,                          // uint nmt
-	     plan.pp.nmt_per_threadblock,               // uint nmt_per_block,
-	     plan.periodic_xcoord,                      // bool periodic_xcoord
-	     partial_pixelization,                      // bool partial_pixelization
-	     local_map.size);                           // long lmap_size
+        tod2map_kernel<T,W,true> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
+            (local_map.data,                            // T *lmap
+             tod.data,                                  // const T *tod
+             xpointing.data,                            // const T *xpointing
+             local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
+             plan.plan_mt,                              // const ulong *plan_mt
+             plan.err_gpu,                              // uint *errflags
+             plan.nsamp,                                // long nsamp
+             plan.nypix_global,                         // int nypix_global
+             plan.nxpix_global,                         // int nxpix_global
+             local_pixelization.nycells,                // int nycells
+             local_pixelization.nxcells,                // int nxcells
+             local_pixelization.ystride,                // long ystride
+             local_pixelization.polstride,              // long polstride
+             plan.pp.plan_nmt,                          // uint nmt
+             plan.pp.nmt_per_threadblock,               // uint nmt_per_block,
+             plan.periodic_xcoord,                      // bool periodic_xcoord
+             partial_pixelization,                      // bool partial_pixelization
+             local_map.size);                           // long lmap_size
     }
     else {
-	tod2map_kernel<T,W,false> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
-	    (local_map.data,                            // T *lmap
-	     tod.data,                                  // const T *tod
-	     xpointing.data,                            // const T *xpointing
-	     local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
-	     plan.plan_mt,                              // const ulong *plan_mt
-	     plan.err_gpu,                              // uint *errflags
-	     plan.nsamp,                                // long nsamp
-	     plan.nypix_global,                         // int nypix_global
-	     plan.nxpix_global,                         // int nxpix_global
-	     local_pixelization.nycells,                // int nycells
-	     local_pixelization.nxcells,                // int nxcells
-	     local_pixelization.ystride,                // long ystride
-	     local_pixelization.polstride,              // long polstride
-	     plan.pp.plan_nmt,                          // uint nmt
-	     plan.pp.nmt_per_threadblock,               // uint nmt_per_block
-	     plan.periodic_xcoord,                      // bool periodic_xcoord
-	     partial_pixelization,                      // bool partial_pixelization
-	     local_map.size);                           // long lmap_size
+        tod2map_kernel<T,W,false> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
+            (local_map.data,                            // T *lmap
+             tod.data,                                  // const T *tod
+             xpointing.data,                            // const T *xpointing
+             local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
+             plan.plan_mt,                              // const ulong *plan_mt
+             plan.err_gpu,                              // uint *errflags
+             plan.nsamp,                                // long nsamp
+             plan.nypix_global,                         // int nypix_global
+             plan.nxpix_global,                         // int nxpix_global
+             local_pixelization.nycells,                // int nycells
+             local_pixelization.nxcells,                // int nxcells
+             local_pixelization.ystride,                // long ystride
+             local_pixelization.polstride,              // long polstride
+             plan.pp.plan_nmt,                          // uint nmt
+             plan.pp.nmt_per_threadblock,               // uint nmt_per_block
+             plan.periodic_xcoord,                      // bool periodic_xcoord
+             partial_pixelization,                      // bool partial_pixelization
+             local_map.size);                           // long lmap_size
     }
 
     CUDA_PEEK("tod2map kernel launch");
-    
+
     uint errflags_to_ignore = partial_pixelization ? errflag_not_in_pixelization : 0;
     check_gpu_errflags(plan.err_gpu, plan.pp.pointing_nblocks, "tod2map", errflags_to_ignore);
 }
@@ -228,13 +228,13 @@ extern void launch_planned_tod2map(
 
 #define INSTANTIATE(T) \
     template void launch_planned_tod2map( \
-	ksgpu::Array<T> &local_map, \
-	const ksgpu::Array<T> &tod, \
-	const ksgpu::Array<T> &xpointing, \
-	const LocalPixelization &local_pixelization, \
-	const PointingPlan &plan, \
-	bool partial_pixelization, \
-	bool debug)
+        ksgpu::Array<T> &local_map, \
+        const ksgpu::Array<T> &tod, \
+        const ksgpu::Array<T> &xpointing, \
+        const LocalPixelization &local_pixelization, \
+        const PointingPlan &plan, \
+        bool partial_pixelization, \
+        bool debug)
 
 INSTANTIATE(float);
 INSTANTIATE(double);

--- a/src_lib/tod2map_response.cu
+++ b/src_lib/tod2map_response.cu
@@ -12,82 +12,36 @@ namespace gpu_mm {
 #endif
 
 
-// The "pre-map2tod" kernel partially zeroes the TOD.
-// Launch with threadIdx = { 32*W } (not {32,W}).
-
+// Helper for tod2map_kernel()
 template<typename T>
-__global__ void pre_map2tod_kernel(T *tod, const ulong *plan_mt, uint nmt, uint nmt_per_block)
-{
-    uint imt0 = (blockIdx.x) * nmt_per_block + threadIdx.x;
-    uint imt1 = (blockIdx.x + 1) * nmt_per_block;
-    imt1 = (imt1 < nmt) ? imt1 : nmt;
-    imt1 = (imt1 + 31U) & ~31U;
-
-    for (uint imt = imt0; imt < imt1; imt += blockDim.x) {
-        uint i = (imt < nmt) ? imt : (nmt-1);
-        ulong mt = plan_mt[i];
-
-        uint icl_flagged = uint(mt >> 20);
-        uint icl = icl_flagged & ((1U << 26) - 1);
-        bool zflag = (icl_flagged & (1U << 27)) != 0;
-        uint mask = __ballot_sync(ALL_LANES, (imt < nmt) && zflag);
-
-        for (uint lane = 0; lane < 32; lane++) {
-            if (mask & (1U << lane)) {
-                uint zcl = __shfl_sync(ALL_LANES, icl, lane);
-                uint s = (ulong(zcl) << 5) + (threadIdx.x & 31);
-                tod[s] = 0;
-            }
-        }
-    }
-}
-
-
-template<typename T>
-static void launch_pre_map2tod(T *tod, const ulong *plan_mt, int nmt)
-{
-    static constexpr int W = 4;  // warps per threadblock
-    static constexpr int nmt_per_block = 1024;
-
-    xassert(tod != nullptr);
-    xassert(plan_mt != nullptr);
-    xassert(nmt > 0);
-
-    int nblocks = (nmt + nmt_per_block - 1) / nmt_per_block;
-
-    pre_map2tod_kernel<T> <<< nblocks, 32*W >>>
-        (tod, plan_mt, nmt, nmt_per_block);
-
-    CUDA_PEEK("pre_map2tod kernel launch");
-}
-
-
-// -------------------------------------------------------------------------------------------------
-
-
-// Helper for map2tod_kernel().
-template<typename T>
-__device__ T eval_tqu(T *sp, int iy, int ix, T cos_2a, T sin_2a)
+__device__ void add_tqu(T *sp, int iy, int ix, T t, T q, T u, T w)
 {
     bool in_cell = ((ix | iy) & ~63) == 0;
     int s = (iy << 6) | ix;
 
-    T ret = in_cell ? (sp[s] + (cos_2a * sp[s+64*64]) + (sin_2a * sp[s+2*64*64])) : 0;
+    // Warp divergence here
+    if (in_cell) {
+        atomicAdd(sp + s, w*t);
+        atomicAdd(sp + s + 64*64, w*q);
+        atomicAdd(sp + s + 2*64*64, w*u);
+    }
+
     __syncwarp();
-    return ret;
 }
 
 
 template<typename T, int W, bool Debug>
 __global__ void __launch_bounds__(32*W, 1)
-map2tod_kernel(
-    T *tod,
-    const T *lmap,
+response_tod2map_kernel(
+    T *lmap,
+    const T *tod,
     const T *xpointing,
+    const T *response, // [{t,p},ndet] flattened
     const long *cell_offsets,
     const ulong *plan_mt,
     uint *errflags,
-    long nsamp,
+    long ndet,
+    long nperdet,
     int nypix_global,
     int nxpix_global,
     int nycells,
@@ -97,7 +51,8 @@ map2tod_kernel(
     uint nmt,
     uint nmt_per_block,
     bool periodic_xcoord,
-    bool partial_pixelization)
+    bool partial_pixelization,
+    long lmap_size)   // for debugging
 {
     // 48 KB in single precision, 96 KB in double precision.
     // __shared__ T shmem[3*64*64];
@@ -116,6 +71,8 @@ map2tod_kernel(
     plan_iterator<W,Debug> iterator(plan_mt, nmt, nmt_per_block);
     pixel_locator<T> px(nypix_global, nxpix_global, periodic_xcoord);
 
+    long nsamp = ndet*nperdet;
+
     // Outer loop over map cells
 
     while (iterator.get_cell()) {
@@ -123,60 +80,77 @@ map2tod_kernel(
         uint iycell = icell >> 10;
         uint ixcell = icell & ((1<<10) - 1);
 
-        bool valid = (iycell < nycells) && (ixcell < nxcells);
+        bool valid = (iycell < nycells) && (ixcell < nxcells);        
         long offset = valid ? cell_offsets[iycell*nxcells + ixcell] : -1;
         err = ((offset >= 0) || partial_pixelization) ? err : errflag_not_in_pixelization;
 
-        // Global -> shared
-
         if (offset >= 0) {
-            for (int y = warpId; y < 64; y += W) {
-                for (int x = laneId; x < 64; x += 32) {
-                    int ss = 64*y + x;                 // shared memory offset
-                    long sg = offset + y*ystride + x;  // global memory offset
-
-                    shmem[ss] = lmap[sg];
-                    shmem[ss + 64*64] = lmap[sg + polstride];
-                    shmem[ss + 2*64*64] = lmap[sg + 2*polstride];
-                }
-            }
-            __syncthreads();
+            // Zero shared memmory
+            for (int s = 32*warpId + laneId; s < 3*64*64; s += 32*W)
+                shmem[s] = 0;
         }
+
+        __syncthreads();
 
         // Inner loop over TOD cache lines
 
         while (iterator.get_cl()) {
-            bool mflag = iterator.icl_flagged & (1U << 26);
+            if (offset < 0)
+                continue;
+
             uint icl = iterator.icl;
             long s = (long(icl) << 5) + laneId;
-
-            if (offset < 0) {
-                if (!mflag)
-                    tod[s] = 0;
-                continue;
-            }
 
             T ypix = xpointing[s];
             T xpix = xpointing[s + nsamp];
             T alpha = xpointing[s + 2*nsamp];
 
+            // Responses
+            long det = s/nperdet;
+            T t_resp = response[det];
+            T p_resp = response[det+ndet];
             T cos_2a, sin_2a;
             dtype<T>::xsincos(2*alpha, &sin_2a, &cos_2a);
+            T t = t_resp*tod[s];
+            T q = p_resp*tod[s]*cos_2a;
+            T u = p_resp*tod[s]*sin_2a;
 
             // Locate pixel in shared memory.
             px.locate(ypix, xpix, iycell, ixcell, err);
 
-            // Interpolate local map in shared memory.
-            // Note: eval_tqu() returns zero if pixel access is outside current map cell.
-            T t = (1-px.dy) * (1-px.dx) * eval_tqu(shmem, px.iy0, px.ix0, cos_2a, sin_2a);
-            t +=  (1-px.dy) *   (px.dx) * eval_tqu(shmem, px.iy0, px.ix1, cos_2a, sin_2a);
-            t +=    (px.dy) * (1-px.dx) * eval_tqu(shmem, px.iy1, px.ix0, cos_2a, sin_2a);
-            t +=    (px.dy) *   (px.dx) * eval_tqu(shmem, px.iy1, px.ix1, cos_2a, sin_2a);
+            add_tqu(shmem, px.iy0, px.ix0, t, q, u, (1-px.dy) * (1-px.dx));
+            add_tqu(shmem, px.iy0, px.ix1, t, q, u, (1-px.dy) * (px.dx));
+            add_tqu(shmem, px.iy1, px.ix0, t, q, u, (px.dy) * (1-px.dx));
+            add_tqu(shmem, px.iy1, px.ix1, t, q, u, (px.dy) * (px.dx));
+        }
 
-            if (mflag)
-                atomicAdd(tod+s, t);
-            else
-                tod[s] = t;
+        if (offset < 0)
+            continue;
+
+        __syncthreads();
+
+        // Shared -> global
+
+        for (int y = warpId; y < 64; y += W) {
+            for (int x = laneId; x < 64; x += 32) {
+                int ss = 64*y + x;                 // shared memory offset
+                long sg = offset + y*ystride + x;  // global memory offset
+
+                T t = shmem[ss];
+                if (!__reduce_or_sync(ALL_LANES, t != 0))
+                    continue;
+
+                // Check for out-of-range memory access
+                if constexpr (Debug) {
+                    assert(polstride > 0);
+                    assert(sg >= 0);
+                    assert(sg + 2*polstride < lmap_size);
+                }
+
+                atomicAdd(lmap + sg, t);
+                atomicAdd(lmap + sg + polstride, shmem[ss+64*64]);
+                atomicAdd(lmap + sg + 2*polstride, shmem[ss+2*64*64]);
+            }
         }
 
         __syncthreads();
@@ -189,10 +163,11 @@ map2tod_kernel(
 
 
 template<typename T>
-void launch_planned_map2tod(
-    ksgpu::Array<T> &tod,                       // shape (nsamp,) or (ndet,nt)
-    const ksgpu::Array<T> &local_map,           // total size (3 * local_pixelization.npix)
+extern void launch_response_tod2map(
+    ksgpu::Array<T> &local_map,                 // total size (3 * local_pixelization.npix)
+    const ksgpu::Array<T> &tod,                 // shape (nsamp,) or (ndet,nt)
     const ksgpu::Array<T> &xpointing,           // shape (3,nsamp) or (3,ndet,nt)    where axis 0 = {y,x,alpha}
+    const ksgpu::Array<T> &response,            // shape (2,ndet)
     const LocalPixelization &local_pixelization, 
     const PointingPlan &plan,
     bool partial_pixelization,
@@ -201,26 +176,28 @@ void launch_planned_map2tod(
     static constexpr int W = 16;  // warps per threadblock
     static constexpr int shmem_nbytes = 3 * 64 * 64 * sizeof(T);
 
-    check_tod(tod, plan.nsamp, "launch_map2tod", true);                      // on_gpu = true
-    check_local_map(local_map, local_pixelization, "launch_map2tod", true);  // on_gpu = true
-    check_xpointing(xpointing, plan.nsamp, "launch_map2tod", true);          // on_gpu = true
+    check_tod(tod, plan.nsamp, "launch_tod2map", true);                      // on_gpu = true
+    check_local_map(local_map, local_pixelization, "launch_tod2map", true);  // on_gpu = true
+    check_xpointing(xpointing, plan.nsamp, "launch_tod2map", true);          // on_gpu = true
+    long ndet, nperdet;
+    check_response(response, plan.nsamp, ndet, nperdet, "launch_response_map2tod", true); // on_gpu = true
 
     // Verify consistency of (nypix, nxpix, periodic_xcoord) between plan and lppix    
     xassert_eq(local_pixelization.nypix_global, plan.nypix_global);
     xassert_eq(local_pixelization.nxpix_global, plan.nxpix_global);
     xassert_eq(local_pixelization.periodic_xcoord, plan.periodic_xcoord);
 
-    launch_pre_map2tod(tod.data, plan.plan_mt, plan.pp.plan_nmt);
-
     if (debug) {
-        map2tod_kernel<T,W,true> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
-            (tod.data,                                  // T *tod
-             local_map.data,                            // const T *lmap
+        response_tod2map_kernel<T,W,true> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
+            (local_map.data,                            // T *lmap
+             tod.data,                                  // const T *tod
              xpointing.data,                            // const T *xpointing
+             response.data,                             // const T *response
              local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
              plan.plan_mt,                              // const ulong *plan_mt
              plan.err_gpu,                              // uint *errflags
-             plan.nsamp,                                // long nsamp
+             ndet,                                      // long ndet (nsamp=ndet*nperdet)
+             nperdet,                                   // long nperdet
              plan.nypix_global,                         // int nypix_global
              plan.nxpix_global,                         // int nxpix_global
              local_pixelization.nycells,                // int nycells
@@ -230,17 +207,20 @@ void launch_planned_map2tod(
              plan.pp.plan_nmt,                          // uint nmt
              plan.pp.nmt_per_threadblock,               // uint nmt_per_block,
              plan.periodic_xcoord,                      // bool periodic_xcoord
-             partial_pixelization);                     // bool partial_pixelization
+             partial_pixelization,                      // bool partial_pixelization
+             local_map.size);                           // long lmap_size
     }
     else {
-        map2tod_kernel<T,W,false> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
-            (tod.data,                                  // T *tod
-             local_map.data,                            // const T *lmap
+        response_tod2map_kernel<T,W,false> <<< plan.pp.pointing_nblocks, {32,W}, shmem_nbytes >>>
+            (local_map.data,                            // T *lmap
+             tod.data,                                  // const T *tod
              xpointing.data,                            // const T *xpointing
+             response.data,                             // const T *response
              local_pixelization.cell_offsets_gpu.data,  // const long *cell_offsets
              plan.plan_mt,                              // const ulong *plan_mt
              plan.err_gpu,                              // uint *errflags
-             plan.nsamp,                                // long nsamp
+             ndet,                                      // long ndet (nsamp=ndet*nperdet)
+             nperdet,                                   // long nperdet
              plan.nypix_global,                         // int nypix_global
              plan.nxpix_global,                         // int nxpix_global
              local_pixelization.nycells,                // int nycells
@@ -248,28 +228,25 @@ void launch_planned_map2tod(
              local_pixelization.ystride,                // long ystride
              local_pixelization.polstride,              // long polstride
              plan.pp.plan_nmt,                          // uint nmt
-             plan.pp.nmt_per_threadblock,               // uint nmt_per_block,
+             plan.pp.nmt_per_threadblock,               // uint nmt_per_block
              plan.periodic_xcoord,                      // bool periodic_xcoord
-             partial_pixelization);                     // bool partial_pixelization
+             partial_pixelization,                      // bool partial_pixelization
+             local_map.size);                           // long lmap_size
     }
 
-    CUDA_PEEK("map2tod kernel launch");
-
-    // FIXME check_gpu_errflags() causes measurable slowdown (0.5 ms/call).
-    // This isn't large enough to be a high priority, but I'd like to revisit it at
-    // some point, mostly for the sake of my own understanding. (I don't understand
-    // why it would slow things down so much!)
+    CUDA_PEEK("tod2map kernel launch");
 
     uint errflags_to_ignore = partial_pixelization ? errflag_not_in_pixelization : 0;
-    check_gpu_errflags(plan.err_gpu, plan.pp.pointing_nblocks, "map2tod", errflags_to_ignore);
+    check_gpu_errflags(plan.err_gpu, plan.pp.pointing_nblocks, "tod2map", errflags_to_ignore);
 }
 
 
 #define INSTANTIATE(T) \
-    template void launch_planned_map2tod( \
-        ksgpu::Array<T> &tod,        \
-        const ksgpu::Array<T> &local_map, \
+    template void launch_response_tod2map( \
+        ksgpu::Array<T> &local_map, \
+        const ksgpu::Array<T> &tod, \
         const ksgpu::Array<T> &xpointing, \
+        const ksgpu::Array<T> &response, \
         const LocalPixelization &local_pixelization, \
         const PointingPlan &plan, \
         bool partial_pixelization, \

--- a/src_pybind11/gpu_mm_pybind11.cu
+++ b/src_pybind11/gpu_mm_pybind11.cu
@@ -161,6 +161,16 @@ PYBIND11_MODULE(gpu_mm_pybind11, m)  // extension module gets compiled to gpu_mm
 	  py::arg("local_pixelization"), py::arg("plan"),
 	  py::arg("partial_pixelization"), py::arg("debug"));    
 
+    m.def("response_map2tod", &gpu_mm::launch_response_map2tod<Tmm>,
+	  py::arg("tod"), py::arg("local_map"), py::arg("xpointing"), py::arg("response"),
+	  py::arg("local_pixelization"), py::arg("plan"),
+	  py::arg("partial_pixelization"), py::arg("debug"));    
+
+    m.def("response_tod2map", &gpu_mm::launch_response_tod2map<Tmm>,
+	  py::arg("local_map"), py::arg("tod"), py::arg("xpointing"), py::arg("response"),
+	  py::arg("local_pixelization"), py::arg("plan"),
+	  py::arg("partial_pixelization"), py::arg("debug"));    
+
     m.def("unplanned_map2tod", &gpu_mm::launch_unplanned_map2tod<Tmm>,
 	  py::arg("tod"), py::arg("local_map"), py::arg("xpointing"),
 	  py::arg("local_pixelization"), py::arg("errflags"),


### PR DESCRIPTION
Added response_map2tod and response_tod2map, which are variants of planned_map2tod and planned_tod2map that accept a response argument, which is a [{t,p},ndet] matrix of per-detector T and P responses. This variant is very slightly slower, but is only called when the new optional argument 'response' is passed to map2tod and tod2map in the python interface. That is - if response isn't passed, everything is done with good old planned_tod2map, etc. The new functions only kick in if this argument is passed.

I also replaced some tabs with 8 spaces where a mix of tabs and spaces had been used for indentation. As it was, the indentation would only make sense if the reader had tabstop set to 8, which is only one of 3-4 common choices (2, 4 8 and maybe 3). So there aren't as many changes as it might look like in the diffs.